### PR TITLE
saturnmoons, jupitermoons - add Z-coord output

### DIFF
--- a/src/base.js
+++ b/src/base.js
@@ -58,7 +58,7 @@ export const COblJ2000 = 0.917482062
  * `dist` is distance in to earth in AU. √(x² + y² + z²)
  * Result in seconds of time.
  * @param {Number} dist - distance in to earth in AU
- * @returns {Number} time for light to travel a given distance in seconds
+ * @returns {Number} time for light to travel a given distance in days
  */
 export function lightTime (dist) {
   // Formula given as (33.3) p. 224.

--- a/src/jupitermoons.js
+++ b/src/jupitermoons.js
@@ -22,13 +22,15 @@ export const callisto = 3
 const k = [17295, 21819, 27558, 36548]
 
 /**
- * XY used for returning coordinates of moons.
+ * XYZ used for returning coordinates of moons.
  * @param {number} x - in units of Jupiter radii
  * @param {number} y - in units of Jupiter radii
+ * @param {number} z - in units of Jupiter radii
  */
-function XY (x, y) {
+function XYZ (x, y, z) {
   this.x = x
   this.y = y
+  this.z = z
 }
 
 /**
@@ -37,7 +39,7 @@ function XY (x, y) {
  * Returned coordinates are in units of Jupiter radii.
  *
  * @param {Number} jde - Julian ephemeris day
- * @return {Array} x, y - coordinates of the 4 Satellites of jupiter
+ * @return {Array} x, y, z - coordinates of the 4 Satellites of jupiter
  */
 export function positions (jde) {
   const d = jde - base.J2000
@@ -83,9 +85,10 @@ export function positions (jde) {
   const r3 = 14.9883 - 0.0216 * cG
   const r4 = 26.3627 - 0.1939 * cH
   const sDE = Math.sin(DE)
+  const cDE = Math.cos(DE)
   const xy = function (u, r) {
     const [su, cu] = base.sincos(u)
-    return new XY(r * su, -r * cu * sDE)
+    return new XYZ(r * su, -r * cu * sDE, -r * cu * cDE)
   }
   return [xy(u1 + c1, r1), xy(u2 + c2, r2), xy(u3 + c3, r3), xy(u4 + c4, r4)]
 }
@@ -101,7 +104,7 @@ export function positions (jde) {
  * @param {Planet} earth - VSOP87 Planet earth
  * @param {Planet} jupiter - VSOP87 Planet jupiter
  * @param {Array} [pos] - reference to array of positions (same as return value)
- * @return {Array} x, y - coordinates of the 4 Satellites of jupiter
+ * @return {Array} x, y, z - coordinates of the 4 Satellites of jupiter
  */
 export function e5 (jde, earth, jupiter, pos) {
   pos = pos || new Array(4)
@@ -481,7 +484,7 @@ export function e5 (jde, earth, jupiter, pos) {
     x += Math.abs(z) / k[i] * Math.sqrt(1 - d * d)
     // perspective effect
     const W = Δ / (Δ + z / 2095)
-    pos[i] = new XY(x * W, y * W)
+    pos[i] = new XYZ(x * W, y * W, z)
   }
   return pos
 }

--- a/src/saturnmoons.js
+++ b/src/saturnmoons.js
@@ -25,11 +25,12 @@ export const hyperion = 6
 export const iapetus = 7
 
 /**
- * XY holds coordinates returned from positions().
+ * XYZ holds coordinates returned from positions().
  */
-function XY (x, y) {
+function XYZ (x, y, z) {
   this.x = x
   this.y = y
+  this.z = z
 }
 
 const d = Math.PI / 180
@@ -44,7 +45,7 @@ const d = Math.PI / 180
  * @param {number} jde - Julian ephemeris day
  * @param {Planet} earth - VSOP87 planet Earth // eslint-disable-line no-unused-vars
  * @param {Planet} saturn - VSOP87 planet Saturn // eslint-disable-line no-unused-vars
- * @return {XY[]} Array of Moon Positions in `XY`
+ * @return {XYZ[]} Array of Moon Positions in `XYZ`
  *   Use `M.mimas ... M.iapetus` to resolve to Moon and its position at `jde`
  */
 export function positions (jde, earth, saturn) {
@@ -138,7 +139,7 @@ export function positions (jde, earth, saturn) {
     const d = X[j] / s4[j].r
     X[j] += Math.abs(Z[j]) / k[j] * Math.sqrt(1 - d * d)
     const W = Δ / (Δ + Z[j] / 2475)
-    pos[j - 1] = new XY(X[j] * W, Y[j] * W)
+    pos[j - 1] = new XYZ(X[j] * W, Y[j] * W, Z[j])
   }
   return pos
 }

--- a/test/jupitermoons.test.js
+++ b/test/jupitermoons.test.js
@@ -18,6 +18,11 @@ describe('#jupitermoons', function () {
       assert.strictEqual(float(pos[2].y).toFixed(2), +0.65)
       assert.strictEqual(float(pos[3].y).toFixed(2), +1.10)
 
+      assert.strictEqual(float(pos[0].z).toFixed(2), -4.82)
+      assert.strictEqual(float(pos[1].z).toFixed(2), -5.74)
+      assert.strictEqual(float(pos[2].z).toFixed(2), -14.94)
+      assert.strictEqual(float(pos[3].z).toFixed(2), -25.22)
+
       // Output:
       // X  -3.44  +7.44  +1.24  +7.08
       // Y  +0.21  +0.25  +0.65  +1.10
@@ -38,11 +43,13 @@ describe('#jupitermoons', function () {
 
       assert.deepStrictEqual(xyToFixed(pos3[2]), {
         x: -0.0016,
-        y: -0.8424
+        y: -0.8424,
+        z: -14.9444
       })
       assert.deepStrictEqual(xyToFixed(pos4[3]), {
         x: +0.0555,
-        y: +1.4811
+        y: +1.4811,
+        z: +26.2743
       })
 
       // Output:
@@ -67,6 +74,11 @@ describe('#jupitermoons', function () {
       assert.strictEqual(float(pos[2].y).toFixed(4), +0.5900)
       assert.strictEqual(float(pos[3].y).toFixed(4), +1.0290)
 
+      assert.strictEqual(float(pos[0].z).toFixed(4), -4.8189)
+      assert.strictEqual(float(pos[1].z).toFixed(4), -5.7472)
+      assert.strictEqual(float(pos[2].z).toFixed(4), -14.9406)
+      assert.strictEqual(float(pos[3].z).toFixed(4), -25.2244)
+
       // Output:
       // X  -3.4503  +7.4418  +1.2010  +7.0720
       // Y  +0.2137  +0.2752  +0.5900  +1.0290
@@ -90,11 +102,13 @@ describe('#jupitermoons', function () {
 
       assert.deepStrictEqual(xyToFixed(pos3[2]), {
         x: +0.0032,
-        y: -0.8042
+        y: -0.8042,
+        z: -14.9433
       })
       assert.deepStrictEqual(xyToFixed(pos4[3]), {
         x: +0.0002,
-        y: +1.3990
+        y: +1.3990,
+        z: +26.2732
       })
 
       // Output:
@@ -108,6 +122,7 @@ function xyToFixed (xy, n) {
   n = n || 4
   return {
     x: float(xy.x).toFixed(n),
-    y: float(xy.y).toFixed(n)
+    y: float(xy.y).toFixed(n),
+    z: float(xy.z).toFixed(n)
   }
 }

--- a/test/saturnmoons.test.js
+++ b/test/saturnmoons.test.js
@@ -9,6 +9,7 @@ describe('#saturnmoons', function () {
   function comp (res, exp) {
     assert.strictEqual(float(res.x).toFixed(3), exp.x)
     assert.strictEqual(float(res.y).toFixed(3), exp.y)
+    assert.strictEqual(float(res.z).toFixed(3), exp.z)
   }
 
   describe('positions()', function () {
@@ -17,14 +18,14 @@ describe('#saturnmoons', function () {
     const saturn = new planetposition.Planet(data.vsop87Bsaturn)
     const pos = saturnmoons.positions(2451439.50074, earth, saturn)
     const exp = [
-      { x:  +3.102, y: -0.204 },
-      { x:  +3.823, y: +0.318 },
-      { x:  +4.027, y: -1.061 },
-      { x:  -5.365, y: -1.148 },
-      { x:  -0.972, y: -3.136 },
-      { x: +14.568, y: +4.738 },
-      { x: -18.001, y: -5.328 },
-      { x: -48.760, y: +4.137 }
+      { x:  +3.102, y: -0.204, z: +0.295 },
+      { x:  +3.823, y: +0.318, z: -0.833 },
+      { x:  +4.027, y: -1.061, z: +2.545 },
+      { x:  -5.365, y: -1.148, z: +3.004 },
+      { x:  -0.972, y: -3.136, z: +8.080 },
+      { x: +14.568, y: +4.738, z: -12.755 },
+      { x: -18.001, y: -5.328, z: +15.121 },
+      { x: -48.760, y: +4.137, z: +32.738 }
     ]
 
     pos.forEach(function (p, i) {


### PR DESCRIPTION
Add the `Z`-coordinate to the computed positions of the moons, so that transits, eclipses, occultations, and shadow transits can be more easily computed.

At this moment we do not know of any published "official" Z-values to check against, so we use whatever values would satisfy the test at the moment and hard-code them into the test files.